### PR TITLE
Fix meta data missing for Throwable

### DIFF
--- a/Poly_SimpleThrowSystem.js
+++ b/Poly_SimpleThrowSystem.js
@@ -187,6 +187,8 @@ var stsParams = {};
             if (objCopy.hasOwnProperty(property))
                 newSkill[property] = objCopy[property];
         });
+		// meta data got lost somewhere.
+		this.extractMetadata(newSkill);
         // set throw message
         newSkill.message1 = stsParams.throwMessage;
         // reset occasion (items shouldn't be throwable outside battle)


### PR DESCRIPTION
The meta object was missing from skills created with `StsSkillify`. Using the previous object's note to generate my not be 100% correct behavior but quite a few plugins handle items, skills, etc. the same so it ends up working pretty well.